### PR TITLE
Cleanup Jekyll template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="{{ site.title | default: site.github.repository_name }} : {{ site.description | default: site.github.project_tagline }}">
+    <meta name="description" content="{{ site.title }} : {{ site.description }}">
 
     <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
 
@@ -19,15 +19,8 @@
             <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
             <a id="docs_banner" href="{{ site.github.repository_url }}/wiki">Documentation</a>
 
-            <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
-            <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}<a href="https://www.nuget.org/packages/FluentAssertions/"><img src="https://img.shields.io/nuget/v/FluentAssertions.svg?style=flat-square" style="width:18%;float:right"/></a></h2>
-
-            {% if site.show_downloads %}
-            <section id="downloads">
-                <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
-                <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
-            </section>
-            {% endif %}
+            <h1 id="project_title">{{ site.title }}</h1>
+            <h2 id="project_tagline">{{ site.description }}<a href="https://www.nuget.org/packages/FluentAssertions/"><img src="https://img.shields.io/nuget/v/FluentAssertions.svg?style=flat-square" style="width:18%;float:right"/></a></h2>
         </header>
     </div>
 
@@ -48,14 +41,9 @@
     <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">
       <footer class="inner">
-        {% if site.github.is_project_page %}
-        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-        {% endif %}
+        <p class="copyright">{{ site.title }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
         <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
       </footer>
     </div>
-
-
-
   </body>
 </html>


### PR DESCRIPTION
Surface-level changes made while browsing through the repo. I think this will help the Jekyll template build slightly faster and also be a little more readable.

* [x] Remove download link if statement
* [x] Remove defaults for items we definitely have in config
* [x] show the ownership information
* [x] remove some whitespace
* [x] remove title/desc defaults since we already them in the config.